### PR TITLE
Introduces a simple Template override CMS for emails

### DIFF
--- a/admin/controllers/Templates.php
+++ b/admin/controllers/Templates.php
@@ -1,0 +1,422 @@
+<?php
+
+/**
+ * This class manages email template overrides
+ *
+ * @package     Nails
+ * @subpackage  module-email
+ * @category    AdminController
+ * @author      Nails Dev Team
+ * @link
+ */
+
+namespace Nails\Admin\Email;
+
+use Nails\Admin\Helper;
+use Nails\Auth\Service\Session;
+use Nails\Common\Exception\FactoryException;
+use Nails\Common\Exception\ModelException;
+use Nails\Common\Exception\ValidationException;
+use Nails\Common\Exception\ViewNotFoundCaseException;
+use Nails\Common\Exception\ViewNotFoundException;
+use Nails\Common\Service\FormValidation;
+use Nails\Common\Service\Input;
+use Nails\Common\Service\Uri;
+use Nails\Common\Service\View;
+use Nails\Email\Constants;
+use Nails\Email\Controller\BaseAdmin;
+use Nails\Email\Model\Template\Override;
+use Nails\Email\Service\Emailer;
+use Nails\Factory;
+
+/**
+ * Class Templates
+ *
+ * @package Nails\Admin\Email
+ */
+class Templates extends BaseAdmin
+{
+    /**
+     * Announces this controller's navGroups
+     *
+     * @return \stdClass
+     */
+    public static function announce()
+    {
+        $oNavGroup = Factory::factory('Nav', 'nails/module-admin');
+        $oNavGroup->setLabel('Email');
+        $oNavGroup->setIcon('fa-paper-plane-o');
+
+        if (userHasPermission('admin:email:templates:edit')) {
+            $oNavGroup->addAction('Manage Templates');
+        }
+
+        return $oNavGroup;
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Returns an array of permissions which can be configured for the user
+     *
+     * @return array
+     */
+    public static function permissions(): array
+    {
+        $aPermissions = parent::permissions();
+
+        $aPermissions['templates:edit'] = 'Can edit templates';
+
+        return $aPermissions;
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Manage Email settings
+     *
+     * @return void
+     */
+    public function index(): void
+    {
+        if (!userHasPermission('admin:email:templates:browse')) {
+            unauthorised();
+        }
+
+        // --------------------------------------------------------------------------
+
+        /** @var Input $oInput */
+        $oInput = Factory::service('Input');
+        /** @var Emailer $oEmailer */
+        $oEmailer = Factory::service('Emailer', Constants::MODULE_SLUG);
+
+        // --------------------------------------------------------------------------
+
+        //  Set method info
+        $this->data['page']->title = 'Manage Templates';
+
+        // --------------------------------------------------------------------------
+
+        //  Get pagination and search/sort variables
+        $iPage      = $oInput->get('page') ? $oInput->get('page') : 0;
+        $iPerPage   = $oInput->get('perPage') ? $oInput->get('perPage') : 50;
+        $sSortOn    = $oInput->get('sortOn') ? $oInput->get('sortOn') : 'name';
+        $sSortOrder = $oInput->get('sortOrder') ? $oInput->get('sortOrder') : 'desc';
+        $sKeywords  = $oInput->get('keywords') ? $oInput->get('keywords') : '';
+
+        // --------------------------------------------------------------------------
+
+        //  Define the sortable columns
+        $aSortColumns = [
+            'name'        => 'Label',
+            'description' => 'Description',
+        ];
+        // --------------------------------------------------------------------------
+
+        $oEmailer = Factory::service('Emailer', Constants::MODULE_SLUG);
+        $aTypes   = $oEmailer->getTypes();
+
+        //  Data for pagination
+        $iTotal = count($aTypes);
+
+        //  Filter out keywords
+        if (!empty($sKeywords)) {
+            $aTypes = array_filter(
+                $aTypes,
+                function ($oType) use ($sKeywords) {
+
+                    if (stripos($oType->slug, $sKeywords) !== false) {
+                        return true;
+                    } elseif (stripos($oType->name, $sKeywords) !== false) {
+                        return true;
+                    } elseif (stripos($oType->description, $sKeywords) !== false) {
+                        return true;
+                    }
+
+                    return false;
+                }
+            );
+            $aTypes = array_filter($aTypes);
+            $aTypes = array_values($aTypes);
+        }
+
+        $iTotal = count($aTypes);
+
+        //  Sort
+        arraySortMulti($aTypes, $sSortOn);
+        if ($sSortOrder === 'DESC') {
+            $aTypes = array_reverse($aTypes);
+        }
+        $aTypes = array_values($aTypes);
+
+        //  Select Page
+        $iPage--;
+        $iPage = $iPage < 0 ? 0 : $iPage;
+
+        //  Select page
+        $iOffset = $iPage * $iPerPage;
+        $aTypes  = array_slice($aTypes, $iOffset, $iPerPage);
+
+        //  Pass to view
+        $this->data['items'] = $aTypes;
+
+        // --------------------------------------------------------------------------
+
+        //  Set Search and Pagination objects for the view
+        $this->data['search']     = Helper::searchObject(
+            true,
+            $aSortColumns,
+            $sSortOn,
+            $sSortOrder,
+            $iPerPage,
+            $sKeywords
+        );
+        $this->data['pagination'] = Helper::paginationObject($iPage, $iPerPage, $iTotal);
+
+        // --------------------------------------------------------------------------
+
+        //  Mimic $aConfig
+        $this->data['CONFIG'] = [
+            'BASE_URL'              => 'admin/email/templates',
+            'PERMISSION'            => null,
+            'INDEX_PAGE_ID'         => null,
+            'INDEX_FIELDS'          => [
+                'Label'       => 'name',
+                'Description' => 'description',
+            ],
+            'INDEX_BOOL_FIELDS'     => [],
+            'INDEX_USER_FIELDS'     => [],
+            'INDEX_NUMERIC_FIELDS'  => [],
+            'INDEX_CENTERED_FIELDS' => [],
+            'INDEX_ROW_BUTTONS'     => [
+                [
+                    'url'   => 'edit/{{slug}}',
+                    'label' => lang('action_edit'),
+                    'class' => 'btn-primary',
+                ],
+                [
+                    'url'   => 'reset/{{slug}}',
+                    'label' => lang('action_reset'),
+                    'class' => 'btn-warning confirm',
+                ],
+            ],
+            'MODEL_INSTANCE'        => (object) [],
+        ];
+
+        // --------------------------------------------------------------------------
+
+        Helper::loadView('index');
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * @throws FactoryException
+     * @throws ModelException
+     * @throws ViewNotFoundCaseException
+     * @throws ViewNotFoundException
+     */
+    public function edit(): void
+    {
+        /** @var Emailer $oEmailer */
+        $oEmailer = Factory::service('Emailer', Constants::MODULE_SLUG);
+        /** @var Uri $oUri */
+        $oUri = Factory::service('Uri');
+        /** @var Input $oInput */
+        $oInput = Factory::service('Input');
+        /** @var Override $oOverrideModel */
+        $oOverrideModel = Factory::model('TemplateOverride', Constants::MODULE_SLUG);
+
+        $oType = $oEmailer->getType($oUri->segment(5));
+        if (empty($oType)) {
+            show404();
+        }
+
+        $oOverride = $oOverrideModel->getBySlug($oType->slug);
+
+        /** @var View $oView */
+        $oView     = Factory::service('View');
+        $sSubject  = $this->normalise($oType->default_subject);
+        $sBodyHtml = $this->normalise(file_get_contents($oView->resolvePath($oType->template_body)));
+        $sBodyText = $this->normalise(file_get_contents($oView->resolvePath($oType->template_body . '_plaintext')));
+
+        if ($oInput->post()) {
+
+            try {
+
+                /** @var FormValidation $oFormValidation */
+                $oFormValidation = Factory::service('FormValidation');
+                $oFormValidation
+                    ->buildValidator([
+                        'subject'   => [
+                            function ($sValue) {
+                                $this->detectPhp($sValue);
+                            },
+                        ],
+                        'body_html' => [
+                            function ($sValue) {
+                                $this->detectPhp($sValue);
+                            },
+                        ],
+                        'body_text' => [
+                            function ($sValue) {
+                                $this->detectPhp($sValue);
+                            },
+                        ],
+                    ])
+                    ->run();
+
+                $aData = [
+                    'subject'   => $this->normalise($oInput->post('subject')),
+                    'body_html' => $this->normalise($oInput->post('body_html')),
+                    'body_text' => $this->normalise($oInput->post('body_text')),
+                ];
+
+                if (empty($aData['subject']) || mb_strlen($aData['subject']) === mb_strlen($oType->default_subject)) {
+                    unset($aData['subject']);
+                }
+
+                if (empty($aData['body_html']) || mb_strlen($aData['body_html']) === mb_strlen($sBodyHtml)) {
+                    unset($aData['body_html']);
+                }
+
+                if (empty($aData['body_text']) || mb_strlen($aData['body_text']) === mb_strlen($sBodyText)) {
+                    unset($aData['body_text']);
+                }
+
+                if (empty($aData) && !empty($oOverride)) {
+                    $oOverrideModel->delete($oOverride->id);
+                } elseif (!empty($aData)) {
+
+                    //  Ensure $aData has all fields
+                    $aData = array_merge(
+                        [
+                            'slug'                    => $oType->slug,
+                            'subject'                 => null,
+                            'subject_original_hash'   => md5($sSubject),
+                            'body_html'               => null,
+                            'body_html_original_hash' => md5($sBodyHtml),
+                            'body_text'               => null,
+                            'body_text_original_hash' => md5($sBodyText),
+                        ],
+                        array_filter($aData)
+                    );
+
+                    if (!empty($oOverride)) {
+                        $oOverrideModel->update($oOverride->id, $aData);
+                    } elseif (!empty($aData)) {
+                        $oOverrideModel->create($aData);
+                    }
+                }
+
+                /** @var Session $oSession */
+                $oSession = Factory::service('Session', 'nails/module-auth');
+                $oSession->setFlashData('success', 'Override updated successfully.');
+                redirect('admin/email/templates/edit/' . $oType->slug);
+
+            } catch (\Exception $e) {
+                $this->data['error'] = 'Failed to set override. ' . $e->getMessage();
+            }
+        }
+
+        $this->data['sDefaultSubject']  = $sSubject;
+        $this->data['sDefaultBodyHtml'] = $sBodyHtml;
+        $this->data['sDefaultBodyText'] = $sBodyText;
+
+        if (!empty($oOverride)) {
+            $this->data['bDefaultSubjectChanged']  = $oOverride->subject_original_hash !== md5($sSubject);
+            $this->data['bDefaultBodyHtmlChanged'] = $oOverride->body_html_original_hash !== md5($sBodyHtml);
+            $this->data['bDefaultBodyTextChanged'] = $oOverride->body_text_original_hash !== md5($sBodyText);
+        } else {
+            $this->data['bDefaultSubjectChanged']  = false;
+            $this->data['bDefaultBodyHtmlChanged'] = false;
+            $this->data['bDefaultBodyTextChanged'] = false;
+        }
+
+        $this->data['oType']       = $oType;
+        $this->data['oOverride']   = $oOverride;
+        $this->data['page']->title = 'Edit Template for: ' . $oType->name;
+        Helper::loadView('edit');
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Normalises a string
+     *
+     * @param string $sString The string to normalise
+     *
+     * @return string
+     */
+    protected function normalise($sString): string
+    {
+        $sString = preg_replace("/\r/", '', $sString);
+        return $sString;
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Detects if a string contains PHP
+     *
+     * @param string $sValue The string to test
+     *
+     * @throws ValidationException
+     */
+    protected function detectPhp(string $sValue): void
+    {
+        if (preg_match('/<\?|<\?php|<\?=/', $sValue)) {
+            throw new ValidationException(
+                'PHP is not supported in template overrides. ' .
+                'Use <a href="https://mustache.github.io/mustache.5.html" targe="_blank">Mustache</a> for ' .
+                'variable substitution and simple logic.'
+            );
+        }
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * Removes an override
+     *
+     * @throws FactoryException
+     * @throws ModelException
+     */
+    public function reset(): void
+    {
+        /** @var Emailer $oEmailer */
+        $oEmailer = Factory::service('Emailer', Constants::MODULE_SLUG);
+        /** @var Uri $oUri */
+        $oUri = Factory::service('Uri');
+        /** @var Override $oOverrideModel */
+        $oOverrideModel = Factory::model('TemplateOverride', Constants::MODULE_SLUG);
+        /** @var Session $oSession */
+        $oSession = Factory::service('Session', 'nails/module-auth');
+
+        $oType = $oEmailer->getType($oUri->segment(5));
+        if (empty($oType)) {
+            show404();
+        }
+
+        $oOverride = $oOverrideModel->getBySlug($oType->slug);
+        if (!empty($oOverride)) {
+            try {
+
+                if (!$oOverrideModel->delete($oOverride->id)) {
+                    throw new ModelException(
+                        'Failed to delete override. ' . $oOverrideModel->lastError()
+                    );
+                }
+
+                $oSession->setFlashData('success', 'Template reset successfully.');
+
+            } catch (\Exception $e) {
+                $oSession->setFlashData('error', $e->getMessage());
+            }
+        } else {
+            $oSession->setFlashData('success', 'Template reset successfully.');
+        }
+
+        redirect('admin/email/templates/index');
+    }
+}

--- a/admin/controllers/Templates.php
+++ b/admin/controllers/Templates.php
@@ -113,11 +113,7 @@ class Templates extends BaseAdmin
         ];
         // --------------------------------------------------------------------------
 
-        $oEmailer = Factory::service('Emailer', Constants::MODULE_SLUG);
-        $aTypes   = $oEmailer->getTypes();
-
-        //  Data for pagination
-        $iTotal = count($aTypes);
+        $aTypes = $oEmailer->getTypes();
 
         //  Filter out keywords
         if (!empty($sKeywords)) {

--- a/admin/controllers/Templates.php
+++ b/admin/controllers/Templates.php
@@ -299,9 +299,17 @@ class Templates extends BaseAdmin
                     );
 
                     if (!empty($oOverride)) {
-                        $oOverrideModel->update($oOverride->id, $aData);
+                        if (!$oOverrideModel->update($oOverride->id, $aData)) {
+                            throw new ValidationException(
+                                'Failed to update override. ' . $oOverrideModel->lastError()
+                            );
+                        }
                     } elseif (!empty($aData)) {
-                        $oOverrideModel->create($aData);
+                        if (!$oOverrideModel->create($aData)) {
+                            throw new ValidationException(
+                                'Failed to create override. ' . $oOverrideModel->lastError()
+                            );
+                        }
                     }
                 }
 

--- a/admin/views/Templates/edit.php
+++ b/admin/views/Templates/edit.php
@@ -1,0 +1,52 @@
+<div class="alert alert-warning">
+    <p>
+        <strong>Editing email templates can have unintended side-effects</strong>
+    </p>
+    <p>
+        Be careful whilst editing email templates, invalid markup can cause layout to break or for the email to fail
+        sending.
+    </p>
+</div>
+<div class="alert alert-info">
+    <p>
+        <strong>Variables and simple logic</strong>
+    </p>
+    <p>
+        Templates support the <a href="https://mustache.github.io/mustache.5.html" targe="_blank">Mustache</a>
+        templating language.
+    </p>
+</div>
+<?=form_open()?>
+<fieldset>
+    <legend>Overrides</legend>
+    <?php
+    echo form_field([
+        'key'         => 'subject',
+        'label'       => 'Subject',
+        'info'        => 'Overrides the subject, including any runtime overrides which may exist (i.e set at time of sending)',
+        'placeholder' => $sDefaultSubject,
+        'default'     => $oOverride->subject ?? $sDefaultSubject,
+        'info'        => $bDefaultSubjectChanged ? '<span class="alert alert-warning">The template has changed since this override was created.</span>' : '',
+    ]);
+    echo form_field_textarea([
+        'key'         => 'body_html',
+        'label'       => 'Body (HTML)',
+        'placeholder' => $sDefaultBodyHtml,
+        'default'     => $oOverride->body_html ?? $sDefaultBodyHtml,
+        'info'        => $bDefaultBodyHtmlChanged ? '<span class="alert alert-warning">The template has changed since this override was created.</span>' : '',
+    ]);
+    echo form_field_textarea([
+        'key'         => 'body_text',
+        'label'       => 'Body (TEXT)',
+        'placeholder' => $sDefaultBodyText,
+        'default'     => $oOverride->body_text ?? $sDefaultBodyText,
+        'info'        => $bDefaultBodyTextChanged ? '<span class="alert alert-warning">The template has changed since this override was created.</span>' : '',
+    ]);
+    ?>
+</fieldset>
+<div class="admin-floating-controls">
+    <button type="submit" class="btn btn-primary">
+        Save Changes
+    </button>
+</div>
+<?=form_open()?>

--- a/admin/views/Templates/index.php
+++ b/admin/views/Templates/index.php
@@ -1,0 +1,2 @@
+<?php
+include NAILS_PATH . 'module-admin/admin/views/DefaultController/index.php';

--- a/migrations/8.php
+++ b/migrations/8.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Migration:   8
+ * Started:     11/10/2019
+ *
+ * @package     Nails
+ * @subpackage  module-email
+ * @category    Database Migration
+ * @author      Nails Dev Team
+ * @link
+ */
+
+namespace Nails\Database\Migration\Nails\ModuleEmail;
+
+use Nails\Common\Console\Migrate\Base;
+
+class Migration8 extends Base
+{
+    /**
+     * Execute the migration
+     *
+     * @return Void
+     */
+    public function execute()
+    {
+        $this->query('
+            CREATE TABLE `{{NAILS_DB_PREFIX}}email_template_override` (
+                `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+                `slug` varchar(150) DEFAULT NULL,
+                `subject` varchar(255) DEFAULT NULL,
+                `subject_original_hash` char(32) DEFAULT NULL,
+                `body_html` text,
+                `body_html_original_hash` char(32) DEFAULT NULL,
+                `body_text` text,
+                `body_text_original_hash` char(32) DEFAULT NULL,
+                `created` datetime NOT NULL,
+                `created_by` int(11) unsigned DEFAULT NULL,
+                `modified` datetime NOT NULL,
+                `modified_by` int(11) unsigned DEFAULT NULL,
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `type` (`slug`),
+                KEY `created_by` (`created_by`),
+                KEY `modified_by` (`modified_by`),
+                CONSTRAINT `{{NAILS_DB_PREFIX}}email_template_override_ibfk_1` FOREIGN KEY (`created_by`) REFERENCES `{{NAILS_DB_PREFIX}}user` (`id`) ON DELETE SET NULL,
+                CONSTRAINT `{{NAILS_DB_PREFIX}}email_template_override_ibfk_2` FOREIGN KEY (`modified_by`) REFERENCES `{{NAILS_DB_PREFIX}}user` (`id`) ON DELETE SET NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+        ');
+    }
+}

--- a/services/services.php
+++ b/services/services.php
@@ -11,20 +11,34 @@ return [
         },
     ],
     'models'    => [
-        'Email' => function () {
+        'Email'            => function () {
             if (class_exists('\App\Email\Model\Email')) {
                 return new \App\Email\Model\Email();
             } else {
                 return new \Nails\Email\Model\Email();
             }
         },
+        'TemplateOverride' => function () {
+            if (class_exists('\App\Email\Model\Template\Override')) {
+                return new \App\Email\Model\Template\Override();
+            } else {
+                return new \Nails\Email\Model\Template\Override();
+            }
+        },
     ],
     'resources' => [
-        'Email' => function ($mObj) {
+        'Email'            => function ($mObj) {
             if (class_exists('\App\Email\Resource\Email')) {
                 return new \App\Email\Resource\Email($mObj);
             } else {
                 return new \Nails\Email\Resource\Email($mObj);
+            }
+        },
+        'TemplateOverride' => function ($mObj) {
+            if (class_exists('\App\Email\Resource\Template\Override')) {
+                return new \App\Email\Resource\Template\Override($mObj);
+            } else {
+                return new \Nails\Email\Resource\Template\Override($mObj);
             }
         },
     ],

--- a/src/Model/Template/Override.php
+++ b/src/Model/Template/Override.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Nails\Email\Model\Template;
+
+use Nails\Common\Model\Base;
+use Nails\Email\Constants;
+
+/**
+ * Class Override
+ *
+ * @package Nails\Email\Model
+ */
+class Override extends Base
+{
+    /**
+     * The table this model represents
+     *
+     * @var string
+     */
+    const TABLE = NAILS_DB_PREFIX . 'email_template_override';
+
+    /**
+     * The name of the resource to use (as passed to \Nails\Factory::resource())
+     *
+     * @var string
+     */
+    const RESOURCE_NAME = 'TemplateOverride';
+
+    /**
+     * The provider of the resource to use (as passed to \Nails\Factory::resource())
+     *
+     * @var string
+     */
+    const RESOURCE_PROVIDER = Constants::MODULE_SLUG;
+}

--- a/src/Resource/Template/Override.php
+++ b/src/Resource/Template/Override.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This class represents objects dispensed by the Override model
+ *
+ * @package  Nails\Email\Resource\Template
+ * @category resource
+ */
+
+namespace Nails\Email\Resource\Template;
+
+use Nails\Common\Resource\Entity;
+
+/**
+ * Class Override
+ *
+ * @package Nails\Email\Resource\Template
+ */
+class Override extends Entity
+{
+}


### PR DESCRIPTION
This PR introduces a system for site admins to customise or tweak the email templates used by the site:

- [x] Admin interface for defining template overrides
- [x] Respected in Emailer
- [x] Can be reset by admin
- [x] Warns admin if underlying template has changed since override created
- [x] Overrides support Mustache

![Screenshot 2019-10-11 12 10 34](https://user-images.githubusercontent.com/233585/66647217-37c0c680-ec20-11e9-81d5-ed902239fe45.png)
![Screenshot 2019-10-11 12 10 51](https://user-images.githubusercontent.com/233585/66647218-37c0c680-ec20-11e9-8488-7a957a9f3a4f.png)
